### PR TITLE
62ndサブディレクトリへ移行するための前準備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # next.js
 /.next/
 /out/
+/apache/
 
 # production
 /build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  apache:
+    image: httpd:latest
+    container_name: test-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - ./apache:/usr/local/apache2/htdocs/
+    # Apacheの設定ファイルを変更したいならここで指定
+    # - ./my-httpd.conf:/usr/local/apache2/conf/httpd.conf

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,13 +1,25 @@
 /** @type {import('next').NextConfig} */
+
+/* 公開時のサブディレクトリ */
+const SUB_DIRECTORY = "/62nd";
+
+/* 本番環境と開発環境の分岐用のフラグ */
+const isProd = process.env.NODE_ENV == "production";
+
 const nextConfig = {
+  basePath: isProd ? SUB_DIRECTORY : "",
   reactStrictMode: true,
   output: "export",
+  distDir: "apache" + SUB_DIRECTORY, // ビルド先のディレクトリ
   trailingSlash: true,
   images: {
     unoptimized: true,
   },
   sassOptions: {
     includePaths: ["./src/styles"],
+  },
+  publicRuntimeConfig: {
+    basePath: isProd ? SUB_DIRECTORY : "",
   },
 };
 

--- a/src/components/Header/BannerImage/BannerImage.tsx
+++ b/src/components/Header/BannerImage/BannerImage.tsx
@@ -1,9 +1,11 @@
+"use client";
+import { basePath } from "@/const/path";
 import styles from "./BannerImage.module.scss";
 
 export default function BannerImage() {
   return (
     <a className={styles.bannerLink} href="/" aria-label="トップに戻る">
-      <img className={styles.banner} src="/img/banner.webp" />
+      <img className={styles.banner} src={`${basePath}/img/banner.webp`} />
     </a>
   );
 }

--- a/src/const/path.ts
+++ b/src/const/path.ts
@@ -1,0 +1,1 @@
+export const basePath = process.env.NODE_ENV === "production" ? "/62nd" : "";


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場合 -->
<!-- - Close #issue番号 -->

## 概要
<!-- 変更内容を簡単に説明 -->
- 62ndサブディレクトリにビルドしたファイルをぶち込んでも動くよう、プログラムを修正する

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- next.configを編集。build時のbasePathを追加
- docker-compose.ymlを作成、本番環境に近い形でapacheを通してlocalで表示を確認できる。
  - 来年以降の担当者がdockerをインストールするのは負担になるため、来年以降使うかは要検討
  - テスト用に使ったが、あって損はないので一旦コミットに含める
- tsxファイルで使う用途にbasePathを作成
  - imgタグのsrcやaタグのhrefには、`${basePath}/path/to/your/iamge`のように 指定する必要あり

## 確認したこと
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
basePathを使ってbannerImageを修正、`npm run dev`と`npm run build`(apache環境)の双方で動くことを確認済み
| dev | build |
|--------|--------|
|![image](https://github.com/user-attachments/assets/e11cdd99-ae16-4992-9532-d6c258df8a06)|![image](https://github.com/user-attachments/assets/0f3ace88-690e-4694-b5d7-01ff11220741) | 

# todo
現状、トップページだけでも多くの画像がうまく表示されないため、basePathを使ってリンクを修正する
また、aタグを使っている箇所のリンクも修正の必要がある

その他の影響範囲は未確認
![image](https://github.com/user-attachments/assets/d4702a3e-98aa-4d4d-9d29-58f20f5df1c6)


# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
