### PR TITLE
デプロイ先を62ndのサブドメインに変更

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
           rsync -avz --delete \
           --exclude-from=./.github/workflows/rsync-exclude.txt \
-          -e "ssh -i private_key -p 8022 -o StrictHostKeyChecking=no" ./out/ $SFTP_USERNAME@$SFTP_HOST:/home/$SFTP_USERNAME/public_html/koudaisai.com/62nd/
+          -e "ssh -i private_key -p 8022 -o StrictHostKeyChecking=no" ./out/ $SFTP_USERNAME@$SFTP_HOST:/home/$SFTP_USERNAME/public_html/62nd.koudaisai.com/
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }} # 秘密鍵
           SFTP_USERNAME: ${{ secrets.SSH_USER_NAME }} # ユーザー名

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
           rsync -avz --delete \
           --exclude-from=./.github/workflows/rsync-exclude.txt \
-          -e "ssh -i private_key -p 8022 -o StrictHostKeyChecking=no" ./out/ $SFTP_USERNAME@$SFTP_HOST:/home/$SFTP_USERNAME/public_html/koudaisai.onamaeweb.jp/
+          -e "ssh -i private_key -p 8022 -o StrictHostKeyChecking=no" ./out/ $SFTP_USERNAME@$SFTP_HOST:/home/$SFTP_USERNAME/public_html/staging.koudaisai.com/
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }} # 秘密鍵
           SFTP_USERNAME: ${{ secrets.SSH_USER_NAME }} # ユーザー名


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場合 -->
<!-- - Close #issue番号 -->

- Close #

## 概要
<!-- 変更内容を簡単に説明 -->
デプロイ先をサブディレクトリからサブドメインに変更

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
これまでの予定では`koudaisai.com/62nd`のように過去の回のページはサブディレクトリに入れていたが、Next.jsの性質上サブディレクトリにアップロードすると画像やscriptのパスに問題が起きていたため、サブディレクトリに変更した
やったこと
- サブドメインを作成
- SSLを設定
- デプロイ先をサブドメインに変更

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
https://62nd.koudaisai.com/

# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
